### PR TITLE
Align Dependabot config with plugin standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,52 @@
 version: 2
+
 updates:
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
     groups:
-      actions-minor-patch:
+      actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      actions-major:
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Actions"
+      include: "scope"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+
+  # Composer (PHP dev dependencies)
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dev-dependencies:
         patterns:
-          - "*"
-        update-types:
-          - "major"
+          - "automattic/*"
+          - "dealerdirect/*"
+          - "php-parallel-lint/*"
+          - "phpcompatibility/*"
+          - "phpunit/*"
+          - "squizlabs/*"
+          - "wp-coding-standards/*"
+          - "yoast/*"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Composer"
+      include: "scope"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary

Dependabot on this repository has only ever watched GitHub Actions. As a result, the plugin's Composer dependencies were never monitored, and the two open high-severity advisories — arbitrary code execution in `wp-coding-standards/wpcs` and unsafe deserialisation in `phpunit/phpunit` — produced no update PRs. Dependabot simply was not looking at that ecosystem.

This change adds a Composer update block and brings the configuration in line with our documented plugin standards. Both ecosystems now use a single grouped update, a `dependencies` label, reviewer assignment, scoped commit-message prefixes, and a five-PR limit. Composer additionally uses `increase-if-necessary` versioning so constraints only move when they have to. The existing weekly schedule and seven-day cooldown are retained, and npm is intentionally omitted since the plugin ships no `package.json`.

The intent is to merge this first so Dependabot can begin surfacing the outstanding Composer updates. The actual dependency and CI modernisation that clears the two advisories follows in a separate pull request, since those constraint changes cascade into the test matrix and workflows.

## Test plan

- [ ] GitHub accepts the `dependabot.yml` without validation errors
- [ ] After merge, confirm Dependabot begins evaluating the Composer ecosystem on its next run