### PR TITLE
Fix cookie-based duplicate-report detection

### DIFF
--- a/class-safe-report-comments.php
+++ b/class-safe-report-comments.php
@@ -364,7 +364,10 @@ class Safe_Report_Comments {
 	 * @return array Decoded cookie data.
 	 */
 	private function unserialize_cookie( $value ) {
-		$data = json_decode( base64_decode( $value ) );
+		// Decode as an associative array. Without the `true` flag, json_decode()
+		// returns a stdClass, which clean_cookie_data()'s is_array() check then
+		// discards, so a flagged comment is never recognised. See #15.
+		$data = json_decode( base64_decode( $value ), true );
 		return $this->clean_cookie_data( $data );
 	}
 


### PR DESCRIPTION
## Summary

Reporting the same comment twice should show the visitor an "already flagged" message rather than silently accepting another report, and the cookie store (`sfrc_flags`) is the primary mechanism behind that check. It has not been working.

`unserialize_cookie()` decodes the stored value with `json_decode( base64_decode( $value ) )`. The stored payload is a JSON object such as `{"19030":1}`, and `json_decode()` returns a `stdClass` for that by default. `clean_cookie_data()` then guards its input with `is_array()`, which a `stdClass` fails, so the decoded data was discarded and replaced with an empty array on every read. The consequence is that a visitor's own prior report was never found in the cookie, `already_flagged()` never matched via the cookie path, and the same comment could be reported repeatedly. The IP/transient fallback masked the effect in many real-world cases, which is why this went unnoticed.

The fix is to pass the associative flag to `json_decode()` so it returns an array that survives the `is_array()` check, restoring cookie-based deduplication. This also resolves the trailing-garbage symptom originally reported in #15: the `sanitize_text_field()` call added to the read path (when the class was split out) strips any leftover URL-encoded `%3D`, leaving valid unpadded base64, and the associative decode then completes cleanly.

This is a one-line change on top of the file split that landed in #13.

Fixes #15.

## Test plan

- [ ] Activate the plugin, enable comment flagging, and approve a test comment.
- [ ] With cookies enabled in the browser, report the comment from the front end.
- [ ] Report the same comment again and confirm the "already flagged" message is shown (previously it accepted the second report).
- [ ] Confirm the `sfrc_flags` cookie decodes to the expected `{ comment_id: count }` data server-side.