### PR TITLE
Enforce code standards in CI

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: "7.4"
+          # Linting and CS run on a recent PHP; the minimum supported version is
+          # checked statically by PHPCompatibilityWP via the testVersion config.
+          php-version: "8.2"
           coverage: none
-          tools: cs2pr
+          tools: composer, cs2pr
 
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
@@ -68,7 +70,9 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: "--prefer-dist --no-progress"
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -83,10 +87,11 @@ jobs:
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
       # Check the code-style consistency of the PHP files.
-      # Temporarily disabled: the plugin carries a backlog of pre-existing WPCS 3.x
-      # violations (see PR #13). Re-enable this gate once that cleanup has landed.
-      # - name: Check PHP code style
-      #   run: composer cs -- --report-full --report-checkstyle=./phpcs-report.xml
-      #
-      # - name: Show PHPCS results in PR
-      #   run: cs2pr ./phpcs-report.xml
+      # continue-on-error lets the next step turn the report into inline
+      # annotations; cs2pr then fails the job if any violations were found.
+      - name: Check PHP code style
+        continue-on-error: true
+        run: composer cs -- --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -68,7 +68,9 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: "--prefer-dist --no-progress"
 
       - name: Start MySQL service
         run: sudo systemctl start mysql.service

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -9,7 +9,12 @@
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
 		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
-	<exclude-pattern>/vendor/</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- The PHPUnit bootstrap necessarily declares unprefixed globals and
+		functions that the WordPress test suite requires by name. -->
+	<exclude-pattern>*/tests/bootstrap.php</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->

--- a/class-safe-report-comments.php
+++ b/class-safe-report-comments.php
@@ -455,7 +455,7 @@ class Safe_Report_Comments {
 				if ( ! isset( $data[ $comment_id ] ) ) {
 					$data[ $comment_id ] = 0;
 				}
-				$data[ $comment_id ]++;
+				++$data[ $comment_id ];
 				$cookie = $this->serialize_cookie( $data );
 				@setcookie( $this->storagecookie, $cookie, time() + $this->cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN );
 				if ( SITECOOKIEPATH != COOKIEPATH ) {
@@ -465,7 +465,7 @@ class Safe_Report_Comments {
 				if ( ! isset( $data[ $comment_id ] ) ) {
 					$data[ $comment_id ] = 0;
 				}
-				$data[ $comment_id ]++;
+				++$data[ $comment_id ];
 				$cookie = $this->serialize_cookie( $data );
 				@setcookie( $this->storagecookie, $cookie, time() + $this->cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN );
 				if ( SITECOOKIEPATH != COOKIEPATH ) {
@@ -485,14 +485,14 @@ class Safe_Report_Comments {
 			if ( ! isset( $transient[ $comment_id ] ) ) {
 				$transient[ $comment_id ] = 0;
 			}
-			$transient[ $comment_id ]++;
+			++$transient[ $comment_id ];
 			set_transient( md5( $this->storagecookie . $remote_addr ), $transient, $this->transient_lifetime );
 		}
 
 
 		$threshold       = (int) get_option( $this->plugin_prefix . '_threshold' );
 		$current_reports = get_comment_meta( $comment_id, $this->plugin_prefix . '_reported', true );
-		$current_reports++;
+		++$current_reports;
 		update_comment_meta( $comment_id, $this->plugin_prefix . '_reported', $current_reports );
 
 
@@ -658,5 +658,4 @@ class Safe_Report_Comments {
 				break;
 		}
 	}
-
 }


### PR DESCRIPTION
## Summary

The PHPCS gate in `cs-lint.yml` has been commented out since the WPCS 3.x upgrade, on the grounds that the plugin carried a backlog of pre-existing violations. That reasoning is now stale: with the fixes from #13 merged, only five violations remained, and every one was auto-fixable and behaviour-preserving. The result was a repository shipping a full VIPCS/WordPress-Extra ruleset that nothing actually enforced.

`phpcbf` clears those five — four stand-alone post-increments become pre-increments, and a stray blank line before the class closing brace goes — after which `phpcs` reports a clean run. That lets the gate come back on: PHPCS writes a checkstyle report and `cs2pr` turns it into inline annotations on the diff, failing the job if anything is found.

The ruleset also picks up the standard `build`, `node_modules` and `vendor` exclusions. The PHPUnit bootstrap is excluded too, since it necessarily declares unprefixed globals and functions the WordPress test suite requires by name — but I scoped that to `tests/bootstrap.php` alone rather than the standard's blanket `*/tests/*`, so any tests written later are still held to the standard.

Separately, `ramsey/composer-install` was the one action the earlier SHA-pinning pass left behind, still on a v1 commit three majors back. It moves to 4.0.0 in both workflows, and linting moves to PHP 8.2 — the minimum supported version is asserted statically by PHPCompatibilityWP's `testVersion`, so the runtime running the sniffs needn't match it.

## Test plan

- [ ] `composer cs` reports no violations (verified locally, exit 0)
- [ ] CS & Lint workflow passes with the PHPCS gate active
- [ ] Integration workflow still passes on the bumped composer-install