### PR TITLE
Prevent flagging of hidden comments such as order notes

### DIFF
--- a/class-safe-report-comments.php
+++ b/class-safe-report-comments.php
@@ -527,6 +527,34 @@ class Safe_Report_Comments {
 	}
 
 	/**
+	 * Determine whether a comment may be reported through the public flagging workflow.
+	 *
+	 * The plugin only ever renders a report link for ordinary, publicly visible comments.
+	 * Other records share the comments table and the same numeric ID space, for example
+	 * WooCommerce order notes ( comment_type 'order_note' ), pingbacks and trackbacks.
+	 * Without this gate, any numeric comment ID accompanied by the global report nonce
+	 * could reach moderation, so the report target is validated before it is acted upon.
+	 *
+	 * @param int $comment_id The comment ID being reported.
+	 * @return bool Whether the comment exists and is an ordinary, reportable comment type.
+	 */
+	public function is_reportable_comment( $comment_id ) {
+		$comment = get_comment( $comment_id );
+
+		// Reject non-existent comments so arbitrary IDs cannot accrue report metadata.
+		if ( ! $comment ) {
+			return false;
+		}
+
+		// Only ordinary comments carry a report link. WordPress stores classic comments with
+		// an empty comment_type; 'comment' is accepted for forward compatibility.
+		$reportable_types = apply_filters( 'safe_report_comments_reportable_comment_types', array( '', 'comment' ) );
+		$is_reportable    = in_array( (string) $comment->comment_type, (array) $reportable_types, true );
+
+		return (bool) apply_filters( 'safe_report_comments_is_reportable_comment', $is_reportable, $comment );
+	}
+
+	/**
 	 * Ajax callback to flag/report a comment.
 	 *
 	 * @todo Confirm this callback only receives POST data
@@ -537,6 +565,12 @@ class Safe_Report_Comments {
 		}
 
 		$comment_id = (int) $_REQUEST['comment_id'];
+
+		// Only ordinary public comments carry a report link; refuse anything else, e.g. order notes.
+		if ( ! $this->is_reportable_comment( $comment_id ) ) {
+			$this->cond_die( $this->invalid_values_message );
+		}
+
 		if ( $this->already_flagged( $comment_id ) ) {
 			$this->cond_die( $this->already_flagged_message );
 		}

--- a/tests/test-reportable-comment.php
+++ b/tests/test-reportable-comment.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests that only ordinary public comments can be reported.
+ *
+ * @package Safe_Report_Comments
+ */
+
+/**
+ * Tests for the report-target validation guard.
+ *
+ * @coversDefaultClass \Safe_Report_Comments
+ */
+class Safe_Report_Comments_Reportable_Comment_Test extends WP_UnitTestCase {
+
+	/**
+	 * Plugin instance under test.
+	 *
+	 * @var Safe_Report_Comments
+	 */
+	protected $plugin;
+
+	/**
+	 * Published post used as the parent for the test comments.
+	 *
+	 * @var int
+	 */
+	protected $post_id;
+
+	/**
+	 * Create the plugin instance and a public parent post.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->plugin  = new Safe_Report_Comments( false );
+		$this->post_id = self::factory()->post->create();
+	}
+
+	/**
+	 * An ordinary comment on a public post is reportable.
+	 *
+	 * @covers ::is_reportable_comment
+	 */
+	public function test_ordinary_comment_is_reportable(): void {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+			)
+		);
+
+		$this->assertTrue( $this->plugin->is_reportable_comment( $comment_id ) );
+	}
+
+	/**
+	 * A comment stored with an explicit 'comment' type is reportable.
+	 *
+	 * @covers ::is_reportable_comment
+	 */
+	public function test_explicit_comment_type_is_reportable(): void {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+				'comment_type'    => 'comment',
+			)
+		);
+
+		$this->assertTrue( $this->plugin->is_reportable_comment( $comment_id ) );
+	}
+
+	/**
+	 * Records that merely share the comments table are not reportable.
+	 *
+	 * Regression: WooCommerce stores internal order notes as comment_type
+	 * 'order_note'. They never carry a public report link, so the anonymous
+	 * flagging workflow must refuse to move them to moderation.
+	 *
+	 * @covers ::is_reportable_comment
+	 * @dataProvider data_non_reportable_types
+	 *
+	 * @param string $comment_type Comment type that must be rejected.
+	 */
+	public function test_non_reportable_comment_types_are_rejected( string $comment_type ): void {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+				'comment_type'    => $comment_type,
+			)
+		);
+
+		$this->assertFalse( $this->plugin->is_reportable_comment( $comment_id ) );
+	}
+
+	/**
+	 * Comment types that must never be reportable.
+	 *
+	 * @return array[]
+	 */
+	public function data_non_reportable_types(): array {
+		return array(
+			'WooCommerce order note' => array( 'order_note' ),
+			'pingback'               => array( 'pingback' ),
+			'trackback'              => array( 'trackback' ),
+		);
+	}
+
+	/**
+	 * A non-existent comment ID is not reportable.
+	 *
+	 * @covers ::is_reportable_comment
+	 */
+	public function test_missing_comment_is_not_reportable(): void {
+		$this->assertFalse( $this->plugin->is_reportable_comment( PHP_INT_MAX ) );
+	}
+
+	/**
+	 * Site owners can opt additional comment types in via the types filter.
+	 *
+	 * @covers ::is_reportable_comment
+	 */
+	public function test_reportable_types_filter_allows_opt_in(): void {
+		$note_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+				'comment_type'    => 'order_note',
+			)
+		);
+
+		$callback = static function ( array $types ): array {
+			$types[] = 'order_note';
+			return $types;
+		};
+
+		add_filter( 'safe_report_comments_reportable_comment_types', $callback );
+		$is_reportable = $this->plugin->is_reportable_comment( $note_id );
+		remove_filter( 'safe_report_comments_reportable_comment_types', $callback );
+
+		$this->assertTrue( $is_reportable );
+	}
+
+	/**
+	 * The final decision filter can veto an otherwise reportable comment.
+	 *
+	 * @covers ::is_reportable_comment
+	 */
+	public function test_is_reportable_comment_filter_can_veto(): void {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+			)
+		);
+
+		add_filter( 'safe_report_comments_is_reportable_comment', '__return_false' );
+		$is_reportable = $this->plugin->is_reportable_comment( $comment_id );
+		remove_filter( 'safe_report_comments_is_reportable_comment', '__return_false' );
+
+		$this->assertFalse( $is_reportable );
+	}
+}


### PR DESCRIPTION
## Summary

Safe Report Comments lets visitors flag a comment as inappropriate, and once a configurable number of reports is reached the comment is moved to moderation. The public AJAX handler behind this, `flag_comment()`, validated only that the submitted `comment_id` was numeric and that the request carried the plugin's report nonce. That nonce is a single global value, shared by every anonymous visitor and not tied to any particular comment, so it proves only that the caller loaded a page with a report link, not that the target was ever meant to be reportable.

WordPress stores more than blog comments in the comments table. WooCommerce, for instance, keeps internal order notes there with a `comment_type` of `order_note`. Because nothing checked the target's type, an anonymous visitor could lift the global nonce from any public post and submit reports against arbitrary comment IDs, including hidden records that never had a report link rendered. On reaching the threshold the plugin called `wp_set_comment_status( $comment_id, 'hold' )` on them, changing their approval state and firing the moderation hooks, with no authorisation for that specific target. This was raised in an external security report, with WooCommerce order notes as the demonstrated case.

The fix adds an `is_reportable_comment()` guard that `flag_comment()` now consults before any report metadata is written or status changed. It confirms the comment exists and is an ordinary public comment type (an empty type or `comment`), rejecting order notes, pingbacks, trackbacks and other subtypes that merely share the table. Two filters keep it extensible: `safe_report_comments_reportable_comment_types` to adjust the accepted types and `safe_report_comments_is_reportable_comment` to veto or allow a specific target. Rejected requests reuse the existing invalid-values response, so client behaviour for a bad request is unchanged. Extracting the check into its own method also makes it directly testable, and the new `tests/test-reportable-comment.php` locks in the behaviour for ordinary comments, order notes, pingbacks, trackbacks, a missing comment and both filters.

The change is deliberately narrow: it gates the target by type only. Verifying parent-post visibility (comments on private or password-protected posts) was noted in the report as a lesser, separate concern, and the `safe_report_comments_is_reportable_comment` filter is the intended extension point should we choose to add it. One claim in the report, that a held order note vanishes from `wc_get_order_notes()`, looked doubtful because `WP_Comment_Query` returns both approved and held comments by default; this PR closes the underlying authorisation gap regardless, since acting on a non-reportable target is wrong on its own.

## Test plan

- [ ] CI runs the new integration test on PHP 7.4 and 8.3 against WordPress latest, single and multisite.
- [ ] Manual: with flagging enabled and WooCommerce active, reporting an `order_note` comment ID via `admin-ajax.php` returns the invalid-values message and leaves the note untouched, while an ordinary comment still reaches moderation at the threshold.