### PR TITLE
Add CHANGELOG.md for the published versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog for Safe Report Comments
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.1] - 2014-07-23
+
+### Fixed
+
+- Typo fix (props @spencermorin).
+
+## [0.4] - 2014-07-23
+
+### Security
+
+- Security fix (h/t vortfu).
+
+## [0.3.2] - 2013-03-06
+
+### Added
+
+- New `safe_report_comments_allow_moderated_to_be_reflagged` filter allows comments to be reflagged after being moderated.
+
+## [0.3.1] - 2012-11-21
+
+### Fixed
+
+- Use `home_url()` for generating the `ajaxurl` on mapped domains, but `admin_url()` where the domain isn't mapped.
+
+## [0.3] - 2012-11-07
+
+### Changed
+
+- Coding standards and cleanup.
+
+[0.4.1]: https://github.com/Automattic/safe-report-comments/compare/0.4...0.4.1
+[0.4]: https://github.com/Automattic/safe-report-comments/compare/0.3.2...0.4
+[0.3.2]: https://github.com/Automattic/safe-report-comments/compare/0.3.1...0.3.2
+[0.3.1]: https://github.com/Automattic/safe-report-comments/compare/0.3...0.3.1


### PR DESCRIPTION
## Summary

The plugin has five published versions on WordPress.org and matching git tags (0.3 through 0.4.1), but no consolidated changelog lived in the repository and the project has never had a single GitHub Release. The only version history was the abbreviated `== Changelog ==` block in `readme.txt`.

This adds a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format, backfilling the five released versions with dates and categorised entries drawn from the existing `readme.txt` history. Each single-line note is grouped under the closest section (the 0.4 security fix under Security, the 0.3.2 filter under Added, and so on), and compare-link references at the foot of the file join each version to its predecessor.

The immediate motivation is to give us a canonical source for GitHub Release notes: each version's section can be promoted a heading level and reused verbatim, so we can finally create the missing Releases in chronological order. Going forward this file becomes the place we record changes ahead of each release.

Only released versions are included; the unreleased commits sitting on `develop`/`main` since 0.4.1 are deliberately left out and can be captured when the next version is cut.