### PR TITLE
Keep spam and trash comments out of the moderation queue

### DIFF
--- a/class-safe-report-comments.php
+++ b/class-safe-report-comments.php
@@ -507,8 +507,13 @@ class Safe_Report_Comments {
 		}
 
 		if ( $current_reports >= $threshold ) {
-			do_action( 'safe_report_comments_mark_flagged', $comment_id );
-			wp_set_comment_status( $comment_id, 'hold' );
+			// Only pull the comment into the moderation queue if it is currently approved.
+			// Comments already in spam or trash have been dealt with, so reporting them
+			// should not resurrect them back into the moderation queue.
+			if ( 'approved' === wp_get_comment_status( $comment_id ) ) {
+				do_action( 'safe_report_comments_mark_flagged', $comment_id );
+				wp_set_comment_status( $comment_id, 'hold' );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Once a comment reached the report threshold, `mark_flagged()` set its status to `hold` unconditionally. This meant a comment that Akismet had already caught as spam, or that a moderator had already trashed, would be dragged back into the moderation queue the moment enough visitors reported it. From the moderator's point of view, comments they had already dealt with kept reappearing.

The plugin does have a guard against re-flagging, but it only protects comments that reached the approved state via `comment_unapproved_to_approved`. Anything sent straight to spam or trash never sets that flag, so it was left unprotected.

This change restricts the status change to comments that are currently approved. Approved comments are still pulled into moderation as before, while spam and trashed comments are left exactly where the moderator (or Akismet) put them. The `safe_report_comments_mark_flagged` action now fires only when a comment is genuinely flagged, which is the more accurate signal for anything hooking into it.

Fixes #16

## Test plan

- [ ] Enable flagging with a threshold (e.g. 4)
- [ ] Mark a comment as spam or move it to trash
- [ ] Report that comment enough times to cross the threshold
- [ ] Confirm it stays in spam/trash rather than returning to the moderation queue
- [ ] Report an approved comment past the threshold and confirm it is still moved to hold