### PR TITLE
Automate WordPress.org SVN deployment on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types: [released] # Trigger when a (non-prerelease) release is published.
+
+# Disable all permissions by default; grant minimal permissions per job.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org SVN
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: WordPress.org plugin deploy
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
+        env:
+          SLUG: safe-report-comments
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
## Summary

WordPress.org remains the primary distribution channel for Safe Report Comments, but until now there was no automated route from a GitHub release to the plugin's SVN repository. Updating trunk and the tagged version was a manual SVN exercise, which is both easy to forget after a release and easy to get subtly wrong.

This adds a `deploy.yml` workflow that publishes to WordPress.org whenever a GitHub release is published, using the 10up plugin deploy action. Releasing on GitHub now keeps GitHub and WordPress.org in step automatically. The workflow follows the repository's established hardening: permissions are denied by default and narrowed to `contents: read` for the job, git credentials are not persisted, and third-party actions are pinned to commit SHAs (checkout at v7.0.1 to match the other workflows).

What ships to users is governed by the existing `.distignore`, and screenshots are served from the `.wordpress-org` assets directory that is already in the repository. No other push-to-SVN mechanism existed to remove; the only `svn` usage in the repo is the read-only core and test-suite export in `bin/install-wp-tests.sh`, which is unrelated and untouched.

Deployment authenticates with the `SVN_USERNAME` and `SVN_PASSWORD` repository secrets, which have been configured.

## Notes for reviewers

- The workflow triggers on `release: [released]`, so pre-releases do not deploy.
- The version shipped is whatever is in `readme.txt` and the plugin header at release time. Both currently read `0.4.1`, so a release should only be cut once the version has been bumped to avoid re-publishing (or downgrading) the live version.
- There is no companion `release.yml` yet, so GitHub releases are still created manually. That can follow separately if we want tag pushes to build the release automatically.