### PR TITLE
Keep README.md in plugin distributions and archives

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -19,7 +19,6 @@
 /composer.json
 /composer.lock
 /phpunit.xml.dist
-/readme.md
 
 # Caches and logs
 /.phpunit.cache/

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,7 +23,6 @@
 /composer.json                   export-ignore
 /composer.lock                   export-ignore
 /phpunit.xml.dist                export-ignore
-/readme.md                       export-ignore
 
 # Auto detect text files and perform LF normalization
 # https://pablorsk.medium.com/be-a-git-ninja-the-gitattributes-file-e58c07c9e915


### PR DESCRIPTION
## Summary

The readme is the source of the WordPress.org plugin page: WordPress.org reads `README.md` when no `readme.txt` is present, and this plugin relies on that. For the listing to build correctly, the readme has to reach every distribution channel, but two config files were quietly stripping it out.

`.distignore` excluded it from the WordPress.org SVN deploy and any rsync-based build, while an `export-ignore` entry in `.gitattributes` removed it from `git archive` output and GitHub's auto-generated release ZIPs. Between them, no consumer of a packaged build received the readme.

This change drops both entries so `README.md` ships everywhere it needs to. As a side note, the old rules both referenced a lowercase `readme.md` that never matched the actual `README.md` on case-sensitive targets such as the SVN server and Linux CI, so they were misleading as well as harmful.