### PR TITLE
Make the report link appear reliably across all themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Report link no longer disappears on themes that modify the comment reply-link markup, such as Twenty Twenty. It is now positioned in the browser next to the reply link rather than by parsing that markup server-side (#14).
+- Report link now appears on comments at the maximum threading depth, where WordPress renders no reply link.
+- Report link now appears in block themes that render comments with the Comment Content block, not only classic `wp_list_comments()` output.
+
+### Changed
+
+- In automatic mode the report link is attached via the `comment_text` filter and positioned client-side, instead of via the `comment_reply_link` filter.
+
+### Removed
+
+- Internal `add_flagging_link()` method and the `safe_report_comments_comment_reply_link` filter, which the new placement mechanism no longer uses.
+
 ## [0.4.1] - 2014-07-23
 
 ### Fixed
@@ -35,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Coding standards and cleanup.
 
+[Unreleased]: https://github.com/Automattic/safe-report-comments/compare/0.4.1...HEAD
 [0.4.1]: https://github.com/Automattic/safe-report-comments/compare/0.4...0.4.1
 [0.4]: https://github.com/Automattic/safe-report-comments/compare/0.3.2...0.4
 [0.3.2]: https://github.com/Automattic/safe-report-comments/compare/0.3.1...0.3.2

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ This plugin gives your visitors the possibility to report a comment as inappropr
 
 ## Customizations
 
-By default this plugin should hook into most existing themes without any changes, as it attaches itself after the comment reply link via the `comment_reply_link` filter.
+By default this plugin should work with most existing themes without any changes. It appends the flagging link to each comment and then, in the browser, moves it next to that comment's reply link. The reply link is located via its core `data-commentid` attribute, so placement does not depend on your theme's specific markup.
 
-If that does not work for your theme, you can place the flagging link manually. Define `no_autostart_safe_report_comments` in your theme's `functions.php` file and initialize the class with auto-attachment disabled: `$safe_report_comments = new Safe_Report_Comments( false );`.
+The report link ships unstyled and inherits your theme's link styles from wherever it appears, so it can look different next to a reply link than at the end of a comment (the deepest threading level, which has no reply link). To adjust or unify its appearance, target the `.safe-comments-report-link` class in your theme's CSS.
+
+If you would rather control the placement yourself, you can place the flagging link manually. Define `no_autostart_safe_report_comments` in your theme's `functions.php` file and initialize the class with auto-attachment disabled: `$safe_report_comments = new Safe_Report_Comments( false );`.
 
 Here is an example of a custom setup in `functions.php` that places the flagging link via a comment callback function.
 
@@ -101,9 +103,9 @@ function mytheme_comment( $comment, $args, $depth ) {
 
 There are various other actions and filters within the plugin that allow you to alter its behaviour. Please see the inline documentation for details.
 
-## Known issues
+## Notes
 
-Automatic mode implementation currently does not work with threaded comments in the last level of threading. As the plugin attaches itself to the comment reply link, which is not displayed once the maximum threading level is reached, the abuse link is missing at this point. As a workaround, set the threading level higher than the likely depth of your comment threads.
+At the maximum threading depth WordPress does not render a reply link, so in automatic mode the flagging link stays at the end of the comment rather than moving next to a reply link. The link still works as normal. Earlier versions attached to the reply link itself and so showed no flagging link at all at this depth.
 
 ## Changelog
 

--- a/class-safe-report-comments.php
+++ b/class-safe-report-comments.php
@@ -214,7 +214,7 @@ class Safe_Report_Comments {
 		add_action( 'wp_enqueue_scripts', array( $this, 'action_enqueue_scripts' ) );
 
 		if ( $this->auto_init ) {
-			add_filter( 'comment_reply_link', array( $this, 'add_flagging_link' ) );
+			add_filter( 'comment_text', array( $this, 'append_flagging_link' ), 100, 2 );
 		}
 		add_action( 'comment_report_abuse_link', array( $this, 'print_flagging_link' ) );
 
@@ -235,7 +235,7 @@ class Safe_Report_Comments {
 
 		$ajaxurl = apply_filters( 'safe_report_comments_ajax_url', $ajaxurl );
 
-		wp_enqueue_script( $this->plugin_prefix . '-ajax-request', $this->plugin_url . '/js/ajax.js', array( 'jquery' ), '1.0', true );
+		wp_enqueue_script( $this->plugin_prefix . '-ajax-request', $this->plugin_url . '/js/ajax.js', array( 'jquery' ), '2.0', true );
 		wp_localize_script( $this->plugin_prefix . '-ajax-request', 'SafeCommentsAjax', array( 'ajaxurl' => $ajaxurl ) ); // slightly dirty but needed due to possible problems with mapped domains.
 	}
 
@@ -645,20 +645,55 @@ class Safe_Report_Comments {
 	}
 
 	/**
-	 * Callback function to automatically hook in the report link after the comment reply link.
-	 * If you want to control the placement on your own define no_autostart_safe_report_comments in your functions.php file and initialize the class
-	 * with $safe_report_comments = new Safe_Report_Comments( $auto_init = false );
+	 * Append the report link to a comment so the bundled script can position it.
 	 *
-	 * @param string $comment_reply_link Comment reply link markup.
-	 * @return string Modified comment reply link markup.
+	 * Registered on the `comment_text` filter in automatic mode. The previous approach
+	 * parsed the theme-rendered reply-link markup with a regular expression and injected
+	 * the report link into it. That broke whenever a theme altered the reply link, for
+	 * example Twenty Twenty prepends a `do-not-scroll` class, which stopped the pattern
+	 * from matching and silently dropped the link.
+	 *
+	 * Instead the link is rendered at the end of the comment and moved next to the reply
+	 * link on the client, keyed off the reply link's core `data-commentid` attribute, so
+	 * placement no longer depends on any particular markup. This works for both classic
+	 * (`wp_list_comments()`) and block themes, and reaches comments at the maximum
+	 * threading depth, which have no reply link for the old approach to target.
+	 *
+	 * To place the link yourself, disable automatic mode (see the `no_autostart_safe_report_comments`
+	 * constant) and call `do_action( 'comment_report_abuse_link' )` in your comment template.
+	 *
+	 * @param string          $comment_text Text of the current comment.
+	 * @param WP_Comment|null $comment      The current comment object, when provided.
+	 * @return string Comment text, with the report link appended for reportable comments.
 	 */
-	public function add_flagging_link( $comment_reply_link ) {
-		if ( ! preg_match_all( '#^(.*)(<a.+class=["|\']comment-(reply|login)-link["|\'][^>]+>)(.+)(</a>)(.*)$#msiU', $comment_reply_link, $matches ) ) {
-			return '<!-- safe-comments add_flagging_link not matching -->' . $comment_reply_link;
+	public function append_flagging_link( $comment_text, $comment = null ) {
+		// Never add the link within feeds.
+		if ( is_feed() ) {
+			return $comment_text;
 		}
 
-		$comment_reply_link = $matches[1][0] . $matches[2][0] . $matches[4][0] . $matches[5][0] . '<span class="safe-comments-report-link">' . $this->get_flagging_link() . '</span>' . $matches[6][0];
-		return apply_filters( 'safe_report_comments_comment_reply_link', $comment_reply_link );
+		$comment_id = is_object( $comment ) ? (int) $comment->comment_ID : (int) get_comment_ID();
+
+		// Only ordinary public comments carry a report link, so skip pingbacks, order notes, etc.
+		if ( ! $comment_id || ! $this->is_reportable_comment( $comment_id ) ) {
+			return $comment_text;
+		}
+
+		$link = $this->get_flagging_link( $comment_id );
+
+		// Nothing to show; for example, the visitor has already reported this comment.
+		if ( '' === trim( $link ) ) {
+			return $comment_text;
+		}
+
+		// Hidden until the script positions and reveals it; reporting requires JavaScript.
+		$wrapper = sprintf(
+			'<span class="safe-comments-report-link" data-comment-id="%d" style="display:none;">%s</span>',
+			$comment_id,
+			$link
+		);
+
+		return $comment_text . $wrapper;
 	}
 
 	/**

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -1,5 +1,5 @@
 function safe_report_comments_flag_comment( comment_id, nonce, result_id ) {
-	jQuery.post( 
+	jQuery.post(
 		SafeCommentsAjax.ajaxurl,
 		{
 			comment_id : comment_id,
@@ -10,12 +10,38 @@ function safe_report_comments_flag_comment( comment_id, nonce, result_id ) {
 				withCredentials: true
 			}
 		},
-		function(data) { jQuery( '#'+result_id).html(data); }
+		function( data ) { jQuery( '#' + result_id ).html( data ); }
 	);
 	return false;
 }
 
-jQuery( document ).ready( function() {
-	jQuery( '.hide-if-js' ).hide();
-	jQuery( '.hide-if-no-js' ).show();
-});
+jQuery( function( $ ) {
+	// Legacy visibility toggling for manually placed links, e.g. a theme that
+	// calls do_action( 'comment_report_abuse_link' ) in its comment template.
+	$( '.hide-if-js' ).hide();
+	$( '.hide-if-no-js' ).show();
+
+	// In automatic mode the report link is rendered at the end of each comment and
+	// hidden. Move it next to that comment's reply link, then reveal it. The reply
+	// link is found via its core data-commentid attribute, so placement does not
+	// depend on the theme's markup (the previous server-side regex broke whenever a
+	// theme altered the reply link, e.g. Twenty Twenty prepends a class). This works
+	// for classic and block themes alike. Comments at the maximum threading depth have
+	// no reply link, so their link is left in place at the end of the comment.
+	var positioned = {};
+
+	$( '.safe-comments-report-link' ).each( function() {
+		var $wrapper   = $( this );
+		var commentId  = $wrapper.data( 'comment-id' );
+		var $replyLink = $( '.comment-reply-link[data-commentid="' + commentId + '"]' ).first();
+
+		// Only move the first link for each comment, so a comment shown more than once
+		// on a page (for example, also in a widget) does not stack links by the reply link.
+		if ( $replyLink.length && ! positioned[ commentId ] ) {
+			$replyLink.after( $wrapper );
+			positioned[ commentId ] = true;
+		}
+
+		$wrapper.show();
+	} );
+} );

--- a/tests/test-append-flagging-link.php
+++ b/tests/test-append-flagging-link.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for the client-positioned report link placement.
+ *
+ * @package Safe_Report_Comments
+ */
+
+/**
+ * Covers Safe_Report_Comments::append_flagging_link().
+ */
+class Safe_Report_Comments_Append_Flagging_Link_Test extends WP_UnitTestCase {
+
+	/**
+	 * Plugin instance under test, created with automatic attachment disabled.
+	 *
+	 * @var Safe_Report_Comments
+	 */
+	private $plugin;
+
+	/**
+	 * An ordinary, reportable comment ID.
+	 *
+	 * @var int
+	 */
+	private $comment_id;
+
+	/**
+	 * Create the plugin instance and a reportable comment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->plugin = new Safe_Report_Comments( false );
+
+		$this->comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::factory()->post->create(),
+				'comment_content' => 'A reportable comment.',
+			)
+		);
+	}
+
+	/**
+	 * A reportable comment gets the hidden report wrapper, tagged with its ID.
+	 */
+	public function test_appends_wrapper_for_reportable_comment() {
+		$output = $this->plugin->append_flagging_link( 'Original text.', get_comment( $this->comment_id ) );
+
+		$this->assertStringStartsWith( 'Original text.', $output );
+		$this->assertStringContainsString( 'class="safe-comments-report-link"', $output );
+		$this->assertStringContainsString( 'data-comment-id="' . $this->comment_id . '"', $output );
+		$this->assertStringContainsString( 'style="display:none;"', $output );
+		$this->assertStringContainsString( 'safe_report_comments_flag_comment(', $output );
+	}
+
+	/**
+	 * Non-reportable comment types, such as pingbacks, never receive a report link.
+	 */
+	public function test_skips_non_reportable_comment_type() {
+		$pingback_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::factory()->post->create(),
+				'comment_type'    => 'pingback',
+				'comment_content' => 'A pingback.',
+			)
+		);
+
+		$output = $this->plugin->append_flagging_link( 'Original text.', get_comment( $pingback_id ) );
+
+		$this->assertSame( 'Original text.', $output );
+	}
+
+	/**
+	 * The report link is not appended within feeds.
+	 */
+	public function test_skips_in_feed() {
+		$this->go_to( '/?feed=rss2' );
+
+		$output = $this->plugin->append_flagging_link( 'Original text.', get_comment( $this->comment_id ) );
+
+		$this->assertSame( 'Original text.', $output );
+	}
+}


### PR DESCRIPTION
Closes #14.

## Summary

The report link was placed by taking the theme-rendered comment reply link and rewriting its HTML with a regular expression. That coupled the plugin to one particular markup shape, so any theme that touched the reply link broke the match and the link silently disappeared, with nothing to hint at why. Twenty Twenty is the reported case in #14: it prepends a `do-not-scroll` class to the reply link, which stops the pattern from matching. The same brittleness meant the link never appeared on comments at the maximum threading depth, where no reply link exists, nor in block themes.

Rather than parse markup, the link is now appended to each comment through the `comment_text` filter and repositioned in the browser next to the reply link, located by the reply link's core `data-commentid` attribute. Placement no longer depends on any particular markup, so it works whether or not a theme alters the reply link, and it degrades gracefully: where there is no reply link (the deepest thread level), the link simply stays at the end of the comment. This brings block themes, which render comments with the Comment Content block, into the same code path as classic themes.

One behavioural change worth noting: the link is rendered hidden and revealed by the script, so visitors without JavaScript no longer see a dead link (reporting has always required JavaScript). The internal `add_flagging_link()` method and its `safe_report_comments_comment_reply_link` filter are removed as no longer used; the public `safe_report_comments_flagging_link` and `_flagging_link_text` filters and the manual `do_action( 'comment_report_abuse_link' )` path are unchanged. The link inherits theme styles from wherever it lands, so its appearance can differ between the two positions; the README documents `.safe-comments-report-link` as the styling hook.

## Test plan

- [ ] Enable flagging under **Settings → Discussion** and set a threshold.
- [ ] On a classic theme (e.g. Twenty Twenty) and a block theme (e.g. Twenty Twenty-Five), confirm a report link appears on every comment: next to Reply where present, and at the end of the comment at maximum threading depth.
- [ ] Click it and confirm the AJAX thank-you message; confirm reporting the same comment again is refused.
- [ ] Confirm pingbacks and other non-public comment types get no link.
- [ ] `composer test` (integration tests in `tests/test-append-flagging-link.php`).